### PR TITLE
fix(SideDrawer): fix for multiple navigating

### DIFF
--- a/modules/shared/side-drawer-page/side-drawer-page.component.ts
+++ b/modules/shared/side-drawer-page/side-drawer-page.component.ts
@@ -84,6 +84,7 @@ export class SideDrawerPageComponent implements AfterViewInit, OnDestroy {
               animated: false
             });
           this.isContentVisible = true;
+          this.drawer.off('drawerClosed');
         });
       });
     }


### PR DESCRIPTION
Without this fix you will encounter a bug when trying to navigate via SideDrawer two times - it will return to the current route, as event listener hasn't been cleared.